### PR TITLE
Repo naming

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -25,6 +25,7 @@ class repo_centos::base {
   }
 
   yumrepo { 'CentOS-Base':
+    name       => 'base',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Base',

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -21,10 +21,10 @@ class repo_centos::base {
 
   # Yumrepo ensure only in Puppet >= 3.5.0
   if versioncmp($::puppetversion, '3.5.0') >= 0 {
-    Yumrepo <| title == 'centos-base' |> { ensure => $repo_centos::ensure_base }
+    Yumrepo <| title == 'CentOS-Base' |> { ensure => $repo_centos::ensure_base }
   }
 
-  yumrepo { 'centos-base':
+  yumrepo { 'CentOS-Base':
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Base',

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -26,7 +26,7 @@ class repo_centos::base {
 
   yumrepo { 'CentOS-Base':
     name       => 'base',
-    target     => 'CentOS-Base.repo',
+    target     => '/etc/yum.repos.d/CentOS-Base.repo',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Base',

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -26,6 +26,7 @@ class repo_centos::base {
 
   yumrepo { 'CentOS-Base':
     name       => 'base',
+    target     => 'CentOS-Base.repo',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Base',

--- a/manifests/clean.pp
+++ b/manifests/clean.pp
@@ -3,12 +3,5 @@
 class repo_centos::clean {
 
   file { "/etc/yum.repos.d/centos${repo_centos::releasever}.repo": ensure => absent }
-  file { '/etc/yum.repos.d/CentOS-Base.repo': ensure => absent }
-  file { '/etc/yum.repos.d/CentOS-Vault.repo': ensure => absent }
-  file { '/etc/yum.repos.d/CentOS-Debuginfo.repo': ensure => absent }
-  file { '/etc/yum.repos.d/CentOS-Media.repo': ensure => absent }
-  file { '/etc/yum.repos.d/CentOS-Sources.repo': ensure => absent }
-  file { '/etc/yum.repos.d/CentOS-SCL.repo': ensure => absent }
-  file { '/etc/yum.repos.d/CentOS-fasttrack.repo': ensure => absent }
 
 }

--- a/manifests/clean.pp
+++ b/manifests/clean.pp
@@ -2,6 +2,21 @@
 #
 class repo_centos::clean {
 
-  file { "/etc/yum.repos.d/centos${repo_centos::releasever}.repo": ensure => absent }
+  file { [
+    "/etc/yum.repos.d/centos${repo_centos::releasever}.repo",
+    '/etc/yum.repos.d/centos-base.repo',
+    '/etc/yum.repos.d/centos-base-source.repo',
+    '/etc/yum.repos.d/centos-contrib.repo',
+    '/etc/yum.repos.d/centos-cr.repo',
+    '/etc/yum.repos.d/centos-debug.repo',
+    '/etc/yum.repos.d/centos-extras.repo',
+    '/etc/yum.repos.d/centos-fasttrack.repo',
+    '/etc/yum.repos.d/centos-plus.repo',
+    '/etc/yum.repos.d/centos-scl.repo',
+    '/etc/yum.repos.d/centos-updates.repo',
+    '/etc/yum.repos.d/centos-updates-source.repo',
+  ]:
+    ensure => absent,
+  }
 
 }

--- a/manifests/contrib.pp
+++ b/manifests/contrib.pp
@@ -22,10 +22,10 @@ class repo_centos::contrib {
 
   # Yumrepo ensure only in Puppet >= 3.5.0
   if versioncmp($::puppetversion, '3.5.0') >= 0 {
-    Yumrepo <| title == 'centos-contrib' |> { ensure => $repo_centos::ensure_contrib }
+    Yumrepo <| title == 'CentOS-Contrib' |> { ensure => $repo_centos::ensure_contrib }
   }
 
-  yumrepo { 'centos-contrib':
+  yumrepo { 'CentOS-Contrib':
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Contrib',

--- a/manifests/cr.pp
+++ b/manifests/cr.pp
@@ -19,10 +19,10 @@ class repo_centos::cr {
 
   # Yumrepo ensure only in Puppet >= 3.5.0
   if versioncmp($::puppetversion, '3.5.0') >= 0 {
-    Yumrepo <| title == 'centos-cr' |> { ensure => $repo_centos::ensure_cr }
+    Yumrepo <| title == 'CentOS-CR' |> { ensure => $repo_centos::ensure_cr }
   }
 
-  yumrepo { 'centos-cr':
+  yumrepo { 'CentOS-CR':
     baseurl  => "${repo_centos::repourl}/\$releasever/cr/\$basearch/",
     descr    => 'CentOS-$releasever - CR',
     enabled  => $enabled,

--- a/manifests/cr.pp
+++ b/manifests/cr.pp
@@ -24,7 +24,7 @@ class repo_centos::cr {
 
   yumrepo { 'CentOS-CR':
     name     => 'cr',
-    target   => 'CentOS-CR.repo',
+    target   => '/etc/yum.repos.d/CentOS-CR.repo',
     baseurl  => "${repo_centos::repourl}/\$releasever/cr/\$basearch/",
     descr    => 'CentOS-$releasever - CR',
     enabled  => $enabled,

--- a/manifests/cr.pp
+++ b/manifests/cr.pp
@@ -24,6 +24,7 @@ class repo_centos::cr {
 
   yumrepo { 'CentOS-CR':
     name     => 'cr',
+    target   => 'CentOS-CR.repo',
     baseurl  => "${repo_centos::repourl}/\$releasever/cr/\$basearch/",
     descr    => 'CentOS-$releasever - CR',
     enabled  => $enabled,

--- a/manifests/cr.pp
+++ b/manifests/cr.pp
@@ -23,6 +23,7 @@ class repo_centos::cr {
   }
 
   yumrepo { 'CentOS-CR':
+    name     => 'cr',
     baseurl  => "${repo_centos::repourl}/\$releasever/cr/\$basearch/",
     descr    => 'CentOS-$releasever - CR',
     enabled  => $enabled,

--- a/manifests/debug.pp
+++ b/manifests/debug.pp
@@ -23,7 +23,7 @@ class repo_centos::debug {
 
   yumrepo { 'CentOS-Debuginfo':
     name     => 'base-debuginfo',
-    target   => 'CentOS-Debug.repo',
+    target   => '/etc/yum.repos.d/CentOS-Debug.repo',
     baseurl  => "${repo_centos::debug_repourl}/${repo_centos::releasever}/\$basearch/",
     descr    => "CentOS-${repo_centos::releasever} - Debuginfo",
     enabled  => $enabled,

--- a/manifests/debug.pp
+++ b/manifests/debug.pp
@@ -22,6 +22,7 @@ class repo_centos::debug {
   }
 
   yumrepo { 'CentOS-Debug':
+    name     => 'debug',
     baseurl  => "${repo_centos::debug_repourl}/${repo_centos::releasever}/\$basearch/",
     descr    => "CentOS-${repo_centos::releasever} - Debuginfo",
     enabled  => $enabled,

--- a/manifests/debug.pp
+++ b/manifests/debug.pp
@@ -18,11 +18,12 @@ class repo_centos::debug {
 
   # Yumrepo ensure only in Puppet >= 3.5.0
   if versioncmp($::puppetversion, '3.5.0') >= 0 {
-    Yumrepo <| title == 'CentOS-Debug' |> { ensure => $repo_centos::ensure_debug }
+    Yumrepo <| title == 'CentOS-Debuginfo' |> { ensure => $repo_centos::ensure_debug }
   }
 
-  yumrepo { 'CentOS-Debug':
-    name     => 'debug',
+  yumrepo { 'CentOS-Debuginfo':
+    name     => 'base-debuginfo',
+    target   => 'CentOS-Debug.repo',
     baseurl  => "${repo_centos::debug_repourl}/${repo_centos::releasever}/\$basearch/",
     descr    => "CentOS-${repo_centos::releasever} - Debuginfo",
     enabled  => $enabled,

--- a/manifests/debug.pp
+++ b/manifests/debug.pp
@@ -18,10 +18,10 @@ class repo_centos::debug {
 
   # Yumrepo ensure only in Puppet >= 3.5.0
   if versioncmp($::puppetversion, '3.5.0') >= 0 {
-    Yumrepo <| title == 'centos-debug' |> { ensure => $repo_centos::ensure_debug }
+    Yumrepo <| title == 'CentOS-Debug' |> { ensure => $repo_centos::ensure_debug }
   }
 
-  yumrepo { 'centos-debug':
+  yumrepo { 'CentOS-Debug':
     baseurl  => "${repo_centos::debug_repourl}/${repo_centos::releasever}/\$basearch/",
     descr    => "CentOS-${repo_centos::releasever} - Debuginfo",
     enabled  => $enabled,

--- a/manifests/extras.pp
+++ b/manifests/extras.pp
@@ -32,7 +32,7 @@ class repo_centos::extras {
 
   yumrepo { 'CentOS-Extras':
     name       => 'extras',
-    target     => 'CentOS-Base.repo',
+    target     => '/etc/yum.repos.d/CentOS-Base.repo',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Extras',

--- a/manifests/extras.pp
+++ b/manifests/extras.pp
@@ -31,6 +31,7 @@ class repo_centos::extras {
   }
 
   yumrepo { 'CentOS-Extras':
+    name       => 'extras',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Extras',

--- a/manifests/extras.pp
+++ b/manifests/extras.pp
@@ -27,10 +27,10 @@ class repo_centos::extras {
 
   # Yumrepo ensure only in Puppet >= 3.5.0
   if versioncmp($::puppetversion, '3.5.0') >= 0 {
-    Yumrepo <| title == 'centos-extras' |> { ensure => $repo_centos::ensure_extras }
+    Yumrepo <| title == 'CentOS-Extras' |> { ensure => $repo_centos::ensure_extras }
   }
 
-  yumrepo { 'centos-extras':
+  yumrepo { 'CentOS-Extras':
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Extras',

--- a/manifests/extras.pp
+++ b/manifests/extras.pp
@@ -32,6 +32,7 @@ class repo_centos::extras {
 
   yumrepo { 'CentOS-Extras':
     name       => 'extras',
+    target     => 'CentOS-Base.repo',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Extras',

--- a/manifests/fasttrack.pp
+++ b/manifests/fasttrack.pp
@@ -31,6 +31,7 @@ class repo_centos::fasttrack {
   }
 
   yumrepo { 'CentOS-fasttrack':
+    name       => 'fasttrack',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - fasttrack',

--- a/manifests/fasttrack.pp
+++ b/manifests/fasttrack.pp
@@ -27,10 +27,10 @@ class repo_centos::fasttrack {
 
   # Yumrepo ensure only in Puppet >= 3.5.0
   if versioncmp($::puppetversion, '3.5.0') >= 0 {
-    Yumrepo <| title == 'centos-fasttrack' |> { ensure => $repo_centos::ensure_fasttrack }
+    Yumrepo <| title == 'CentOS-fasttrack' |> { ensure => $repo_centos::ensure_fasttrack }
   }
 
-  yumrepo { 'centos-fasttrack':
+  yumrepo { 'CentOS-fasttrack':
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - fasttrack',

--- a/manifests/fasttrack.pp
+++ b/manifests/fasttrack.pp
@@ -32,7 +32,7 @@ class repo_centos::fasttrack {
 
   yumrepo { 'CentOS-fasttrack':
     name       => 'fasttrack',
-    target     => 'CentOS-fasttrack.repo',
+    target     => '/etc/yum.repos.d/CentOS-fasttrack.repo',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - fasttrack',

--- a/manifests/fasttrack.pp
+++ b/manifests/fasttrack.pp
@@ -32,6 +32,7 @@ class repo_centos::fasttrack {
 
   yumrepo { 'CentOS-fasttrack':
     name       => 'fasttrack',
+    target     => 'CentOS-fasttrack.repo',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - fasttrack',

--- a/manifests/plus.pp
+++ b/manifests/plus.pp
@@ -32,6 +32,7 @@ class repo_centos::plus {
 
   yumrepo { 'CentOS-Plus':
     name       => 'centosplus',
+    target     => 'CentOS-Base.repo',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Plus',

--- a/manifests/plus.pp
+++ b/manifests/plus.pp
@@ -31,6 +31,7 @@ class repo_centos::plus {
   }
 
   yumrepo { 'CentOS-Plus':
+    name       => 'centosplus',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Plus',

--- a/manifests/plus.pp
+++ b/manifests/plus.pp
@@ -27,10 +27,10 @@ class repo_centos::plus {
 
   # Yumrepo ensure only in Puppet >= 3.5.0
   if versioncmp($::puppetversion, '3.5.0') >= 0 {
-    Yumrepo <| title == 'centos-plus' |> { ensure => $repo_centos::ensure_plus }
+    Yumrepo <| title == 'CentOS-Plus' |> { ensure => $repo_centos::ensure_plus }
   }
 
-  yumrepo { 'centos-plus':
+  yumrepo { 'CentOS-Plus':
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Plus',

--- a/manifests/plus.pp
+++ b/manifests/plus.pp
@@ -32,7 +32,7 @@ class repo_centos::plus {
 
   yumrepo { 'CentOS-Plus':
     name       => 'centosplus',
-    target     => 'CentOS-Base.repo',
+    target     => '/etc/yum.repos.d/CentOS-Base.repo',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Plus',

--- a/manifests/scl.pp
+++ b/manifests/scl.pp
@@ -30,6 +30,7 @@ class repo_centos::scl {
     }
 
     yumrepo { 'CentOS-SCL':
+      name     => 'scl',
       baseurl  => "${repo_centos::repourl}/\$releasever/SCL/\$basearch/",
       descr    => 'CentOS-$releasever - SCL',
       enabled  => $enabled,

--- a/manifests/scl.pp
+++ b/manifests/scl.pp
@@ -26,10 +26,10 @@ class repo_centos::scl {
   if $repo_centos::releasever == '6' {
     # Yumrepo ensure only in Puppet >= 3.5.0
     if versioncmp($::puppetversion, '3.5.0') >= 0 {
-      Yumrepo <| title == 'centos-scl' |> { ensure => $repo_centos::ensure_scl }
+      Yumrepo <| title == 'CentOS-SCL' |> { ensure => $repo_centos::ensure_scl }
     }
 
-    yumrepo { 'centos-scl':
+    yumrepo { 'CentOS-SCL':
       baseurl  => "${repo_centos::repourl}/\$releasever/SCL/\$basearch/",
       descr    => 'CentOS-$releasever - SCL',
       enabled  => $enabled,

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -16,6 +16,7 @@ class repo_centos::source {
   }
 
   yumrepo { 'CentOS-Base-source':
+    name     => 'base-source',
     baseurl  => "${repo_centos::source_repourl}/\$releasever/os/Source/",
     descr    => 'CentOS-$releasever - Base Sources',
     enabled  => $enabled,
@@ -24,6 +25,7 @@ class repo_centos::source {
   }
 
   yumrepo { 'CentOS-Updates-source':
+    name     => 'updates-source',
     baseurl  => "${repo_centos::source_repourl}/\$releasever/updates/Source/",
     descr    => 'CentOS-$releasever - Updates Sources',
     enabled  => $enabled,

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -17,7 +17,7 @@ class repo_centos::source {
 
   yumrepo { 'CentOS-Base-source':
     name     => 'base-source',
-    target   => 'CentOS-Sources.repo',
+    target   => '/etc/yum.repos.d/CentOS-Sources.repo',
     baseurl  => "${repo_centos::source_repourl}/\$releasever/os/Source/",
     descr    => 'CentOS-$releasever - Base Sources',
     enabled  => $enabled,
@@ -27,7 +27,7 @@ class repo_centos::source {
 
   yumrepo { 'CentOS-Updates-source':
     name     => 'updates-source',
-    target   => 'CentOS-Sources.repo',
+    target   => '/etc/yum.repos.d/CentOS-Sources.repo',
     baseurl  => "${repo_centos::source_repourl}/\$releasever/updates/Source/",
     descr    => 'CentOS-$releasever - Updates Sources',
     enabled  => $enabled,

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -17,6 +17,7 @@ class repo_centos::source {
 
   yumrepo { 'CentOS-Base-source':
     name     => 'base-source',
+    target   => 'CentOS-Sources.repo',
     baseurl  => "${repo_centos::source_repourl}/\$releasever/os/Source/",
     descr    => 'CentOS-$releasever - Base Sources',
     enabled  => $enabled,
@@ -26,6 +27,7 @@ class repo_centos::source {
 
   yumrepo { 'CentOS-Updates-source':
     name     => 'updates-source',
+    target   => 'CentOS-Sources.repo',
     baseurl  => "${repo_centos::source_repourl}/\$releasever/updates/Source/",
     descr    => 'CentOS-$releasever - Updates Sources',
     enabled  => $enabled,

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -11,11 +11,11 @@ class repo_centos::source {
 
   # Yumrepo ensure only in Puppet >= 3.5.0
   if versioncmp($::puppetversion, '3.5.0') >= 0 {
-    Yumrepo <| title == 'centos-base-source' |> { ensure => $repo_centos::ensure_source }
-    Yumrepo <| title == 'centos-updates-source' |> { ensure => $repo_centos::ensure_source }
+    Yumrepo <| title == 'CentOS-Base-source' |> { ensure => $repo_centos::ensure_source }
+    Yumrepo <| title == 'CentOS-Updates-source' |> { ensure => $repo_centos::ensure_source }
   }
 
-  yumrepo { 'centos-base-source':
+  yumrepo { 'CentOS-Base-source':
     baseurl  => "${repo_centos::source_repourl}/\$releasever/os/Source/",
     descr    => 'CentOS-$releasever - Base Sources',
     enabled  => $enabled,
@@ -23,7 +23,7 @@ class repo_centos::source {
     gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-${::repo_centos::releasever}",
   }
 
-  yumrepo { 'centos-updates-source':
+  yumrepo { 'CentOS-Updates-source':
     baseurl  => "${repo_centos::source_repourl}/\$releasever/updates/Source/",
     descr    => 'CentOS-$releasever - Updates Sources',
     enabled  => $enabled,

--- a/manifests/updates.pp
+++ b/manifests/updates.pp
@@ -26,7 +26,7 @@ class repo_centos::updates {
 
   yumrepo { 'CentOS-Updates':
     name       => 'updates',
-    target     => 'CentOS-Base.repo',
+    target     => '/etc/yum.repos.d/CentOS-Base.repo',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Updates',

--- a/manifests/updates.pp
+++ b/manifests/updates.pp
@@ -21,10 +21,10 @@ class repo_centos::updates {
 
   # Yumrepo ensure only in Puppet >= 3.5.0
   if versioncmp($::puppetversion, '3.5.0') >= 0 {
-    Yumrepo <| title == 'centos-updates' |> { ensure => $repo_centos::ensure_updates }
+    Yumrepo <| title == 'CentOS-Updates' |> { ensure => $repo_centos::ensure_updates }
   }
 
-  yumrepo { 'centos-updates':
+  yumrepo { 'CentOS-Updates':
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Updates',

--- a/manifests/updates.pp
+++ b/manifests/updates.pp
@@ -25,6 +25,7 @@ class repo_centos::updates {
   }
 
   yumrepo { 'CentOS-Updates':
+    name       => 'updates',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Updates',

--- a/manifests/updates.pp
+++ b/manifests/updates.pp
@@ -26,6 +26,7 @@ class repo_centos::updates {
 
   yumrepo { 'CentOS-Updates':
     name       => 'updates',
+    target     => 'CentOS-Base.repo',
     baseurl    => $baseurl,
     mirrorlist => $mirrorlist,
     descr      => 'CentOS-$releasever - Updates',


### PR DESCRIPTION
I've tweaked the capitalisation of these yum repos so this module takes over management of the same repo files put in place by the `centos-release` RPM. (They won't be overwritten when that RPM is updated because they are marked as configs). It cleans up after itself by deleting the lowercase versions of the repo files.

Tested and working on CentOS 6 and 7, although in some cases I ran into the bug [PUP-2782](https://tickets.puppetlabs.com/browse/PUP-2782) and the files were given the wrong name. This isn't a showstopper, but it can lead to duplicate repos. These are non-problematic and easily cleaned up.

I believe this fulfils your aim for the `4.x` release and doesn't resort to using Augeas :wink: 
